### PR TITLE
6: Add support for nested objects

### DIFF
--- a/src/generateKarate.py
+++ b/src/generateKarate.py
@@ -29,9 +29,9 @@ def getKarateType(prop):
         karateType = '#' + karateType
 
     if oasType == 'object':
-        properties = prop.get('properties', False)
-        if properties:
-            karateType = processProperties(properties)
+        childProperties = prop.get('properties', False)
+        if childProperties:
+            karateType = processProperties(childProperties)
 
     return karateType
 

--- a/src/generateKarate.py
+++ b/src/generateKarate.py
@@ -28,15 +28,14 @@ def getKarateType(prop):
     if nullable:
         karateType = '#' + karateType
 
+    if oasType == 'object':
+        properties = prop.get('properties', False)
+        if properties:
+            karateType = processProperties(properties)
+
     return karateType
 
-def generateKarate(yamlFile):
-    docs = yaml.load(yamlFile)
-    try:
-        properties = docs['properties']
-    except:
-        print("No properties found in file")
-        return
+def processProperties(properties):
     karate = {}
     for prop in properties.keys():
         # WriteOnly properties are not part of the response
@@ -47,3 +46,12 @@ def generateKarate(yamlFile):
         karate[prop] = getKarateType(properties[prop])
     
     return karate
+
+def generateKarate(yamlFile):
+    docs = yaml.load(yamlFile)
+    try:
+        properties = docs['properties']
+    except:
+        print("No properties found in file")
+        return
+    return processProperties(properties)


### PR DESCRIPTION
Now when one of the properties is an object type, this will recursively run the same kind of processing on its child properties. 

Before:

    {
        "a": "#string",
        "b": "#number",
        "c": "#string",
        "d": "#string",
        "e": "#object"
    }


After:

    {
        "a": "#string",
        "b": "#number",
        "c": "#string",
        "d": "#string",
        "e": {
            "1": "#string",
            "2": "#string",
            "3": "#string",
            "4": "#number",
            "5": "#string"
        }
    }

Closes #6