### PR TITLE
Handle properties that are 1-deep refereneces

### DIFF
--- a/src/loadfiles.py
+++ b/src/loadfiles.py
@@ -18,23 +18,38 @@ try:
 except FileExistsError:
     pass
 
+def write_file(outFileName, content):
+    """
+    Writes Karate content to a file
+    """
+    if content is None:
+        print("No content. NOT writing", outFileName)
+        return
+    if 'Kungfu error' in content:
+        print("A valid matcher was NOT created for", outFileName)
+
+    out_file_path = os.path.join(outFolderName, outFileName)
+    with open(out_file_path, 'w') as fp:
+        json.dump(content, fp, indent=4)
+        print("Wrote to: " + out_file_path)
+        #print(json.dumps(karateSchemas[schema], indent=4))
+
 def create_karate_json_of_yaml(yamlFilePath):
+    """
+    Generates one Karate file from one Yaml OpenApi schema file
+    """
     with open(yamlFilePath, 'rb') as f:
         print("Reading " + yamlFilePath)
         karate = generateKarateFromYaml(f)
-    if karate is None:
-        print("Not writing output")
-        return
 
     inFileName = os.path.basename(yamlFilePath)
     outFileName = os.path.splitext(inFileName)[0] + '.json'
-    outFilePath = os.path.join(outFolderName, outFileName)
-    with open(outFilePath, 'w') as fp:
-        json.dump(karate, fp, indent=4)
-        print("Wrote to: " + outFilePath)
-        #print(json.dumps(karate, indent=4))
+    write_file(outFileName, karate)
 
 def parse_full_json_spec(inputFilePath):
+    """
+    Generates multiple Karate files based on one compiled OpenApi specification
+    """
     print("Processing JSON file")
     with open(inputFilePath, 'rb') as f:
         print("Reading " + inputFilePath)
@@ -44,15 +59,8 @@ def parse_full_json_spec(inputFilePath):
         return
 
     for schema in karateSchemas:
-        matcher = karateSchemas[schema]
-        if (matcher is None) or ('Kungfu error' in matcher):
-            print("A valid matcher was NOT created for", schema)
         outFileName = schema + '.json'
-        outFilePath = os.path.join(outFolderName, outFileName)
-        with open(outFilePath, 'w') as fp:
-            json.dump(matcher, fp, indent=4)
-            print("Wrote to: " + outFilePath)
-            #print(json.dumps(karateSchemas[schema], indent=4))
+        write_file(outFileName, karateSchemas[schema])
         
 if os.path.isfile(file_or_directory_path):
     if os.path.splitext(file_or_directory_path)[1] == '.json':

--- a/src/refRetriever.py
+++ b/src/refRetriever.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python
+
+from copy import deepcopy
+
+class RefRetriever():
+    def __init__(self: object, refString: str, specFile: dict):
+        """
+        When an object is instantiated, it immediately processes the reference
+        and saves the result to instance variable `refTarget`.
+        """
+        self.refString = refString
+        self.specFile = specFile
+        self.refTarget = self.getJsonForRef()
+
+    def convertRefStringToKeyList(self):
+        """
+        This creates a list of the keys/indices needed to exctract the desired JSON from the specification object.
+        It removes leading # and converts strings to integers where possible.
+        """
+        pathList = self.refString.split('/')
+        pathList.remove('#')
+        for i in range(len(pathList)):
+            try:
+                pathList[i] = int(pathList[i])
+            except ValueError:
+                pass
+        return pathList
+
+    def getJsonForRef(self):
+        """
+        Returns the part of the spec that the $ref refers to.
+        """
+        pathList = self.convertRefStringToKeyList()
+        jsonSnip = deepcopy(self.specFile)
+
+        for key in pathList:
+            jsonSnip = jsonSnip[key]
+        return jsonSnip
+
+# You can run this file alone if you set `ref` and `inputFilePath` below
+if __name__ == "__main__":
+    import json
+    ref = '#/components/schemas/SomeReferencedSchema'
+    inputFilePath = '/test/this/file.json'
+    with open(inputFilePath, 'rb') as f:
+        docs = json.load(f)
+        print("Reading " + inputFilePath)
+
+        openapiref = RefRetriever(ref, docs)
+        jsonRef = openapiref.refTarget
+        print("result:", jsonRef)


### PR DESCRIPTION
For properties that are references, they now work if their reference is itself a valid property.
Still need to add handling for less-happy paths and other places where `$ref` appears.

There's a blacklists for refs that should not be followed, so `"#/components/schemas/Links"` won't ever actually end up in Karate files.

This breaks reading YAMLs that have refs, so it may be time to remove YAML support.