### PR TITLE
8: Handle allOf cases by collating children as if they're all schemas

### DIFF
--- a/src/generateKarate.py
+++ b/src/generateKarate.py
@@ -101,6 +101,9 @@ def processSchema(schema):
         return processAllOfInSchema(schema['allOf'])
     elif 'oneOf' in schema:
         return processOneOfInSchema(schema['oneOf'])
+    elif '$ref' in schema:
+        ref_schema = processRefProperty(schema)
+        return processSchema(ref_schema)
     else:
         print('No properties found in schema')
         pp.pprint(schema)

--- a/src/generateKarate.py
+++ b/src/generateKarate.py
@@ -76,9 +76,13 @@ def processProperties(properties):
 def processAllOfInSchema(items):
     """
     This should take the contents of a AllOf and return some valid Karate matcher
-    TODO: make this work
     """
-    return {'Kungfu error': 'schema type: allOf'}
+    karate = {}
+    for item in items:
+        item_karate = processSchema(item)
+        if(item_karate):
+            karate = {**karate, **item_karate}
+    return karate
 
 def processOneOfInSchema(items):
     """


### PR DESCRIPTION
This treats children of `allOf` at the schema level as if each is a Schema. It gathers the contents of each "schema" and compiles them into one object using the `**` operator. See "dictionary unpacking" [here](https://treyhunner.com/2016/02/how-to-merge-dictionaries-in-python/).

~~Note: this is not an entirely correct solution, but I'm not sure what logically would be.~~ This actually works pretty well after adding $ref handling. Check it out.